### PR TITLE
Typo in server.py ✒️

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ app = Flask(__name__)
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///sqlitedb.file"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = 0
 
-# configure sqlite3 to enforce foreign key contraints
+# configure sqlite3 to enforce foreign key constraints
 @event.listens_for(Engine, "connect")
 def _set_sqlite_pragma(dbapi_connection, connection_record):
     if isinstance(dbapi_connection, SQLite3Connection):


### PR DESCRIPTION
Fixed typo in line 20.
```python
# configure sqlite3 to enforce foreign key constraints
```
Thanks for the great tutorial and mad respect for coding solely in VIM 🚀